### PR TITLE
Improve SPA Auto-Tracking for Events, Social Interactions, and User Timings

### DIFF
--- a/src/features/auto-tracking.js
+++ b/src/features/auto-tracking.js
@@ -1,6 +1,7 @@
 import config from '../config'
 import { warn, exists } from '../utils'
 import trackPage from './page'
+import set from './set'
 
 /**
  * Enable route autoTracking page
@@ -30,6 +31,7 @@ export default function autoTracking (router) {
       return
     }
 
+    set('page', path)
     trackPage(path, name, window.location.href)
   })
 }


### PR DESCRIPTION
Add a page set to the global router navigation hook that updates the tracker's internal page variable. This ensures that any event, social interaction, or user timing which occurs after the page navigation has the proper page reference.

This conforms to Google's recommendations for [using Google Analytics with Single Page Applications](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications).

Closes issue #24