### PR TITLE
Update page-tracking.md

### DIFF
--- a/docs/page-tracking.md
+++ b/docs/page-tracking.md
@@ -105,7 +105,7 @@ Vue.use(VueAnalytics, {
   autoTracking: {
     pageviewTemplate: function (route) {
       return {
-        path: route.path,
+        page: route.path,
         title: document.title,
         location: window.location.href
       }


### PR DESCRIPTION
Hi Matteo --

Thanks so much for your work on this! I ran into a small isssue when trying to use the custom `pageviewTemplate` and quickly realized it's a quick fix in the docs -- Google Analytics takes `page`, `title` and `description` as parameters and the docs have `page` listed as `path`. Figured correcting this might help some other folks out there. :-)

Thanks!