### PR TITLE
Develop

### DIFF
--- a/src/features/page.auto.js
+++ b/src/features/page.auto.js
@@ -31,5 +31,10 @@ export default function autoTrackPage (router) {
   }
 
   // Track all other pages
-  router.afterEach(() => trackRoute(pageviewProxyFn, router))
+  router.afterEach(() => {
+    setTimeout(() => {
+      // https://github.com/MatteoGabriele/vue-analytics/issues/44
+      trackRoute(pageviewProxyFn, router)
+    }, 0)
+  })
 }

--- a/src/init.js
+++ b/src/init.js
@@ -14,7 +14,7 @@ export default function init (router, callback) {
     return
   }
 
-  const options = config.userId || {}
+  const options = config.userId ? { userId: config.userId } : {}
   const debugSource = config.debug.enabled ? '_debug' : ''
   const source = `https://www.google-analytics.com/analytics${debugSource}.js`
 


### PR DESCRIPTION
- userId is now wrapped within an object when used ( fix #45 )
- page auto tracking uses the current landed url instead of the previous ( fix #44 )