### PR TITLE
Automatically track errors captured by Vue

### DIFF
--- a/__tests__/lib/autotracking.exception.spec.js
+++ b/__tests__/lib/autotracking.exception.spec.js
@@ -1,0 +1,37 @@
+import Vue from 'vue'
+import VueAnalytics from '../../src'
+
+window.ga = jest.fn()
+
+const originalErrorHandler = jest.fn()
+Vue.config.errorHandler = originalErrorHandler
+
+Vue.use(VueAnalytics, {
+  id: 'UA-1234-5',
+  autoTracking: {
+    exception: true,
+  },
+})
+
+const renderError = new Error('render error')
+let $vm
+
+beforeEach(() => {
+  $vm = new Vue({
+    created() {
+      throw renderError
+    }
+  })
+  $vm.$mount()
+})
+
+it('should track Vue render error', () => {
+  expect(window.ga).toBeCalledWith('send', 'exception', {
+    exDescription: 'render error',
+    exFatal: true
+  })
+})
+
+it('should preserve original error handler', () => {
+  expect(originalErrorHandler).toBeCalledWith(renderError, $vm, 'created hook')
+})

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import ga from 'directives/ga'
 
 // Features
 import event from 'lib/event'
-import exception from 'lib/exception'
+import exception, { setupErrorHandler } from 'lib/exception'
 import page from 'lib/page'
 import query from 'lib/query'
 import require from 'lib/require'
@@ -35,6 +35,8 @@ export default function install (Vue, options = {}) {
     ecommerce,
     commands: config.commands
   }
+
+  setupErrorHandler(Vue)
 
   bootstrap()
 }

--- a/src/lib/exception.js
+++ b/src/lib/exception.js
@@ -8,6 +8,18 @@ export default function exception (error, fatal = false) {
   })
 }
 
+export function setupErrorHandler(Vue) {
+  if (config.autoTracking.exception) {
+    const originalErrorHandler = Vue.config.errorHandler
+    Vue.config.errorHandler = function (error, vm, info) {
+      vm.$ga.exception(error.message || error, true)
+      if (typeof originalErrorHandler === 'function') {
+        originalErrorHandler.call(this, error, vm, info)
+      }
+    }
+  }
+}
+
 export function autotracking () {
   if (!config.autoTracking.exception) {
     return


### PR DESCRIPTION
Errors captured by Vue didn't trigger 'error' event on window and therefore wasn't sent to GA.

Registered special handler for that case: https://vuejs.org/v2/api/#errorHandler