### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install vue-analytics
 * [User explorer report](/docs/user-explorer.md)
 * [On Analytics script ready](/docs/when-google-analytics-is-loaded.md)
 * [Custom methods](/docs/custom-methods.md)
-* [Ecommerce](/docs/ecommerce.md)
+* [E-commerce](/docs/ecommerce.md)
 * [Untracked hits](/docs/untracked-hits.md)
 * [Debug](/docs/debug.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,7 @@
 * [Set](/docs/set.md)
 * [Social interactions](/docs/social-interactions.md)
 * [User explorer report](/docs/user-explorer.md)
-* [On Analaytics script ready](/docs/when-google-analytics-is-loaded.md)
+* [On Analytics script ready](/docs/when-google-analytics-is-loaded.md)
 * [Custom methods](/docs/custom-methods.md)
 * [Ecommerce](/docs/ecommerce.md)
 * [Untracked hits](/docs/untracked-hits.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -15,6 +15,6 @@
 * [User explorer report](/docs/user-explorer.md)
 * [On Analytics script ready](/docs/when-google-analytics-is-loaded.md)
 * [Custom methods](/docs/custom-methods.md)
-* [Ecommerce](/docs/ecommerce.md)
+* [E-commerce](/docs/ecommerce.md)
 * [Untracked hits](/docs/untracked-hits.md)
 * [Debug](/docs/debug.md)

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,6 +1,6 @@
 ## Debug
 
-Implements Google Analaytics debug library.
+Implements Google Analytics debug library.
 
 **Please remember that it is for debug only. The file size of analytics\_debug.js is way larger than analytics.js**
 

--- a/docs/ecommerce.md
+++ b/docs/ecommerce.md
@@ -1,6 +1,6 @@
-## Ecommerce
+## E-commerce
 
-All ecommerce features are built-in in the plugin, so there's no need to require any ecommerce libraries: just enable the ecommerce features from the plugin configuration
+All e-commerce features are built-in in the plugin, so there's no need to require any e-commerce libraries: just enable the e-commerce features from the plugin configuration
 
 ```js
 import Vue from 'vue'
@@ -14,7 +14,7 @@ Vue.use(VueAnalytics, {
 })
 ```
 
-It is also possible to use the Enhanced Ecommerce library just by changing the configuration like so
+It is also possible to use the Enhanced E-commerce library just by changing the configuration like so
 
 ```js
 Vue.use(VueAnalytics, {
@@ -39,20 +39,20 @@ Vue.use(VueAnalytics, {
 ```
 
 ### Usage
-All ecommerce features are accessable via the `ecommerce` object
+All e-commerce features are accessable via the `ecommerce` object
 
 - addItem
-- addTransaction 
+- addTransaction
 - addProduct
-- addImpression 
+- addImpression
 - setAction
 - addPromo
 - send
 
-Remember that not all methods are included in the Ecommerce or the Enhanced Ecommerce, so please check the relative documentation in the Google Analytics dev guide.
+Remember that not all methods are included in the E-commerce or the Enhanced E-commerce, so please check the relative documentation in the Google Analytics dev guide.
 
-- [Ecommerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce)
-- [Enhanced Ecommerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
+- [E-commerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce)
+- [Enhanced E-commerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
 
 
 ```html

--- a/docs/when-google-analytics-is-loaded.md
+++ b/docs/when-google-analytics-is-loaded.md
@@ -12,7 +12,7 @@ Vue.use(VueAnalytics, {
     // this is right after the tracker and before every other hit to Google Analytics
   },
   ready () {
-    // here Google Analaytics is ready to track!
+    // here Google Analytics is ready to track!
   }
 })
 ```


### PR DESCRIPTION
There were still some instances of "Analaytics" remaining. (ref #86)

Also, changed Ecommerce to E-commerce since that's the correct way to spell it, according to Wikipedia and [english.stackexchange.com ](https://english.stackexchange.com/questions/174165/correct-spelling-and-or-hyphenation-for-electronic-commerce).