### PR TITLE
Add the possibility to choose other events than just click

### DIFF
--- a/docs/v-ga.md
+++ b/docs/v-ga.md
@@ -71,6 +71,32 @@ Then we only need to add the `v-ga` directive to your element and access the met
 </script>
 ```
 
+By default, the directive is executed when the element is clicked. However, if you want to change the event type for the logging, you can add the proper event as a modifier.
+
+```html
+<template>
+   <input
+      v-model="name"
+      v-ga.focus="$ga.commands.trackFocus.bind(this, 'name')" />
+</template>
+
+<script>
+   export default {
+      name: 'myComponent',
+      data () {
+         return {
+            name: 'John'
+         }
+      },
+      methods: {
+         logName () {
+            console.log(this.name)
+         }
+      }
+   }
+</script>
+```
+
 If there's no need to pass any arguments, we could also just pass the name of the method as a string, and the plugin will look it up for us
 
 ```html

--- a/src/directives/ga.js
+++ b/src/directives/ga.js
@@ -1,17 +1,25 @@
 import config from '../config'
 
 export default {
-  inserted: function (el, { value }, vnode) {
-    el.addEventListener('click', function () {
-      let fn = typeof value === 'string' 
-        ? config.commands[value]
-        : value
+  inserted: function (el, binding, vnode) {
+    const events = Object.keys(binding.modifiers)
 
-      if (!fn) {
-        throw new Error('[vue-analytics] The value passed to v-ga is not defined in the commands list.')
-      }
+    if (events.length === 0) {
+      events.push('click')
+    }
 
-      fn.apply(vnode.context)
+    events.forEach(event => {
+      el.addEventListener(event, function () {
+        let fn = typeof binding.value === 'string'
+          ? config.commands[binding.value]
+          : binding.value
+
+        if (!fn) {
+          throw new Error('[vue-analytics] The value passed to v-ga is not defined in the commands list.')
+        }
+
+        fn.apply(vnode.context)
+      })
     })
   }
 }


### PR DESCRIPTION
Hi,

This is a small contribution to be able to track via directives on other events than just the click.

Motivation
-----
We got a form a bit complex, which has several fields.

We want to be able to determine the drop rate from inside the form to see if we are going in a wrong direction or if one specific form creates complexity for the user.

The rule to make it working is to track blur and/or focus events on the input fields.

Alternatives
-----
We could have create a new method from inside our Vue component but we want to avoid any external behavior to be described from inside our component.

Directive are a much more efficient and clean way to achieve our tracking.

Choices made
-----
To keep backwards compatibility and because it's the most obvious choice, we track by default on the click event.