### PR TITLE
Fix parameter name (path => page)

### DIFF
--- a/docs/page-tracking.md
+++ b/docs/page-tracking.md
@@ -148,7 +148,7 @@ const router = new VueRouter({
           pageviewTemplate (route) {
             return {
               title: 'This is my custom title',
-              path: route.path,
+              page: route.path,
               location: 'www.mydomain.com'
             }
           }


### PR DESCRIPTION
Looks live a typo in the pageviewTemplate example - the correct parameter should be `page` instead of `path`