### PR TITLE
Ensure consistent route tracking

### DIFF
--- a/src/lib/page.js
+++ b/src/lib/page.js
@@ -25,25 +25,11 @@ export default function page (...args) {
   }
 
   if (route) {
-    const {
-      router,
-      autoTracking: {
-        transformQueryString,
-        prependBase
-      }
-    } = config
-
-    const queryString = getQueryString(route.query)
-    const base = router && router.options.base
-    const needsBase = prependBase && base
-
-    let path = route.path + (transformQueryString ? queryString : '')
-    path = needsBase ? getBasePath(base, path) : path
-
-    set('page', path)
-    query('send', 'pageview')
+    trackRoute(route)
   } else {
-    set('page', args[0].page)
+    // We can call with `page('/my/path')`
+    let page = typeof args[0] === 'object' ? args[0].page : args[0]
+    set('page', page)
     query('send', 'pageview', ...args)
   }
 }
@@ -68,7 +54,26 @@ export function trackRoute (route) {
     return
   }
 
-  page(proxy ? proxy(route) : route)
+  if (proxy) {
+    page(proxy(route))
+  } else {
+    const {
+      router,
+      autoTracking: {
+        transformQueryString,
+        prependBase
+      }
+    } = config
+
+    const queryString = getQueryString(route.query)
+    const base = router && router.options.base
+    const needsBase = prependBase && base
+
+    let path = route.path + (transformQueryString ? queryString : '')
+    path = needsBase ? getBasePath(base, path) : path
+    
+    page(path)
+  }
 }
 
 export function autoTracking () {


### PR DESCRIPTION
This is a follow-on from #124 continuing tweaking the behavior of `page()`

There are a couple of fixes/improvements:
 * I believe that https://github.com/MatteoGabriele/vue-analytics/commit/1c2eafe causes problems when calling `page` with a string path as the parameter. The check of the type of args[0] fixes that.
 * This change makes all route tracking work the same, whether automatic or by calling `page($route)` - all route calls are checked for the presence of pageviewTemplate, whether automatic or manual.

Thanks for this package and all you do - I'm not positive that this follows your style, and I'm happy to do the work to adjust if you have concerns - just let me know.