### PR TITLE
feat(config): Allow setting different fields per ID

### DIFF
--- a/__tests__/create-trackers.spec.js
+++ b/__tests__/create-trackers.spec.js
@@ -28,6 +28,35 @@ it ('should initialize multiple trackers', () => {
   })
 })
 
+it('should intialize each id with its own configuration', () => {
+  const customIdFields = { 
+    'UA-12345-1': {
+      clientId: '1'
+    },
+    'UA-54321-1': {
+      clientId: '2'
+    },
+  }
+
+  mockUpdate({ 
+    id: ['UA-12345-1', 'UA-54321-1'], 
+    fields: {
+      'global': true
+    },
+    customIdFields,
+  })
+
+  createTrackers()
+
+  mockGetId().forEach(id => {
+    expect(window.ga).toBeCalledWith('create', id, 'auto', {
+      global: true,
+      ...customIdFields[id],
+      name: getTracker(id),
+    })
+  })
+})
+
 it ('should add linkers if list is not empty', function () {
   mockUpdate({
     id: 'UA-1234-1',

--- a/docs/user-explorer.md
+++ b/docs/user-explorer.md
@@ -11,4 +11,24 @@ Vue.use(VueAnalytics, {
 })
 ```
 
+It's also possible to add fields per id, useful for read only fields.
+
+```js
+Vue.use(VueAnalytics, {
+  id: ['UA-12345-1', 'UA-54321-2'],
+  //fields for both IDS
+  fields: {
+    userId: '1',
+  },
+  customIdFields: {
+    'UA-12345-1': {
+      clientId: '2'
+    },
+    'UA-54321-2': {
+      clientId: '3'
+    }
+  }
+})
+```
+
 **it is also possible to set the **`userId`** in runtime using the **[**set**](/docs/set.md)** method**

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ const defaultConfig = {
   id: null,
   router: null,
   fields: {},
+  customIdFields: {},
   ignoreRoutes: [],
   linkers: [],
   commands: {},

--- a/src/create-trackers.js
+++ b/src/create-trackers.js
@@ -14,7 +14,8 @@ export default function createTrackers () {
 
   ids.forEach(function (domain) {
     const name = getTracker(domain)
-    const options = ids.length > 1 ? { ...config.fields, name } : config.fields
+    const customIdConfig = config.customIdFields[domain] || {}
+    const options = ids.length > 1 ? { ...config.fields, ...customIdConfig, name } : config.fields
 
     window.ga('create', (domain.id || domain), 'auto', options)
   })


### PR DESCRIPTION
feat(config): Allow setting different fields per ID

Closes https://github.com/MatteoGabriele/vue-analytics/issues/143.

Allows setting configuration fields per id.