### PR TITLE
Fix incorrect merge behavior

### DIFF
--- a/__tests__/helpers.spec.js
+++ b/__tests__/helpers.spec.js
@@ -24,6 +24,23 @@ describe('merge', () => {
       }
     })
   })
+
+  it ('should merge objects containing non-objects', () => {
+    const a = { c: [ 1, 2, 3 ], d: Promise.resolve({ a: 1 }) }
+    const b = { c: [ 4, 5 ], d: { b: 1 } }
+    const c = helpers.merge(a, b)
+
+    expect(c).toEqual({
+      c: [
+        4,
+        5,
+        3
+      ],
+      d: {
+        b: 1
+      }
+    })
+  })
 })
 
 describe('getMethod', () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -30,7 +30,9 @@ export function getBasePath (base, path) {
 
 export function merge (obj, src) {
   Object.keys(src).forEach(function (key) {
-    if (obj[key] && typeof obj[key] === 'object') {
+    const type = obj[key] && Object.prototype.toString.call(obj[key])
+
+    if (type === '[object Object]' || type === '[object Array]') {
       merge(obj[key], src[key])
       return
     }


### PR DESCRIPTION
Related to #148.

From the documentation, the `id` option seems to support the Promise that returns an array of IDs, but the current implementation does not successfully `update` the `id` property of `config`, which results in the following error:

```js
Uncaught (in promise) TypeError: e.replace is not a function
```

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Let's say VueAnalytics is instantiated by `id` of Promise that will be resolved by an array of IDs:

```js
Vue.use(VueAnalytics, {
  id: Promise.resolve([ 'UA-XXX-A', 'UA-XXX-B' ])
})
```

This ID will be handled by `update` function, with `response[0]` having a simple Array `[ 'UA-XXX-A', 'UA-XXX-B' ]`.

https://github.com/MatteoGabriele/vue-analytics/blob/b2d88c0a15c4afc989e70b5ce1b6d29faae0d29a/src/bootstrap.js#L41-L45

However, this `update` weirdly merges this Array instance into the aforementioned Promise in the following line:

https://github.com/MatteoGabriele/vue-analytics/blob/b2d88c0a15c4afc989e70b5ce1b6d29faae0d29a/src/helpers.js#L31-L41

As the typeof an instance of `Promise` is `object`, the behavior would look like:

```js
config.id[0] = 'UA-XXX-A';
config.id[1] = 'UA-XXX-B';
```

whereas the correct behavior should simply be replacing `config.id` to the Array instance. This PR detects the type of keys more precisely to avoid unexpected overwrites.

**What is the current behavior? (You can also link to an open issue here)**

`merge` merges any kind of objects, including Promise instances.

**What is the new behavior (if this is a feature change)?**

`merge` only merges a simple object or a simple Array.

**Does this PR introduce a breaking change?**

This breaks the old behavior to some extent but its effect should be low.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [ ] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass
