### PR TITLE
fix(bootstrap): apply any sets before delivering untracked events

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -50,12 +50,12 @@ export default () => {
     // Creates necessary trackers
     createTrackers()
 
+    // Fires all shorthand fields in the options
+    collectors()
+
     // Fires all untracked event that have been fired
     // meanwhile GoogleAnalayitcs script was loading
     untracked()
-
-    // Fires all shorthand fields in the options
-    collectors()
 
     // Starts auto tracking
     autoTracking()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix.


**What is the current behavior? (You can also link to an open issue here)**
https://github.com/MatteoGabriele/vue-analytics/issues/188

**What is the new behavior (if this is a feature change)?**
All set's get applied before any events get dispatched to google analytics

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [ ] Fix/Feature: Docs have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

