### PR TITLE
fix: changed 'utf8' to 'utf-8' for the injected script charset

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,7 +8,7 @@ export function loadScript (url) {
     const script = document.createElement('script')
     script.async = true
     script.src = url
-    script.charset = 'utf8'
+    script.charset = 'utf-8'
 
     head.appendChild(script)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix to helpers.js which specified 'utf8' rather than 'utf-8' for the script element charset.

As an aside this attribute is deprecated on script tags. It is inherited automatically as utf-8 from the document. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Deprecated_attributes

**What is the current behavior?**
Uses invalid/redundant charset value, which causes a warning in most browsers

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [x] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

Originally dealt with in #195 but wrong commit message.
