### PR TITLE
feat: skip tracking dynamically starting from first page

### DIFF
--- a/__tests__/lib/page.spec.js
+++ b/__tests__/lib/page.spec.js
@@ -67,3 +67,21 @@ it ('should set and track page with a VueRouter instance', () => {
   expect(window.ga).toBeCalledWith('set', 'page', '/')
   expect(window.ga).toBeCalledWith('send', 'pageview', '/')
 })
+
+it ('should skip tracking when page first argument is a falsy value', () => {
+  $vm.$ga.page(null)
+  $vm.$ga.page(false)
+  $vm.$ga.page(undefined)
+  // Google officially states that page path must begin with '/'
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#page
+  $vm.$ga.page('')
+
+  expect(window.ga).not.toHaveBeenCalled()
+  expect(window.ga).not.toHaveBeenCalled()
+
+  // Skip behavior must be explicit
+  $vm.$ga.page()
+
+  expect(window.ga).toHaveBeenCalled()
+  expect(window.ga).toHaveBeenCalled()
+})

--- a/docs/page-tracking.md
+++ b/docs/page-tracking.md
@@ -164,6 +164,10 @@ const router = new VueRouter({
 ```
 important: the route pageviewTemplate has always priority over the global one.
 
+`pageviewTemplate` can return a falsy value to skip tracking, which can be useful for specific needs:
+
+- `shouldRouterUpdate` documented below is more appropriate for tracking control based on routing, but is not enough when you need to disable initial tracking on some pages, since it only applies to navigation after initial page load.
+- `pageviewOnLoad: false` is global and can’t depend on current route.
 
 ## Avoid transforming route query object into querystring
 It is possible to avoid route query to be sent as querystring using the `transformQueryString` property
@@ -206,7 +210,7 @@ Vue.use(VueAnalytics, {
 })
 ```
 
-For other use cases it is also possible to use the `shouldRouterUpdate`, accessable in the plugin configuartion object, inside the `autoTracking` property.
+For other use cases it is also possible to use the `shouldRouterUpdate`, accessible in the plugin configuration object, inside the `autoTracking` property.
 The methods has the previous and current route as parameters and it needs to return a truthy or falsy value.
 
 ```js

--- a/src/lib/page.js
+++ b/src/lib/page.js
@@ -11,6 +11,11 @@ import {
 } from '../helpers'
 
 export default function page (...args) {
+  if (args.length && !args[0]) {
+    // allows to dynamically prevent tracking in pageviewTemplate proxy
+    return
+  }
+
   let route
 
   if (args.length && isRouter(args[0])) {


### PR DESCRIPTION
We needed precise control over tracking and as documented in this PR `shouldRouterUpdate` and `pageviewOnLoad: false` were not enough, since the former applies to navigation only, and the latter is global and not dynamic.

Having full control of tracking can be useful avoid app-specific duplicate events with pageviewTemplate, due to SSR or any other reason.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New feature.

**What is the current behavior? (You can also link to an open issue here)**

An object is required and tracking can’t be prevented.

**What is the new behavior (if this is a feature change)?**

`pageviewTemplate` can return a falsy value to prevent tracking as `shouldRouterUpdate` already does.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [x] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

Thanks for vue-analytics!

