### PR TITLE
fix(page): prevent fake / events with pageviewOnLoad when router is not ready

### DIFF
--- a/src/lib/page.js
+++ b/src/lib/page.js
@@ -80,7 +80,7 @@ export function autoTracking () {
     return
   }
 
-  if (autoTracking.pageviewOnLoad) {
+  if (autoTracking.pageviewOnLoad && router.history.ready) {
     trackRoute(router.currentRoute)
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix in page.js to prevent it triggering an invalid '/' path event on _pageviewOnLoad_ when the Vue Router is not yet _ready_.

**What is the current behavior? (You can also link to an open issue here)**
The original problem is described in issue #204

At initialization time, there is a race condition between the Vue Router resolving the landing route and vue-analytics's _pageviewOnLoad_ inquiring for the _currentRoute_.

For users landing on a non-home page, this causes vue-analytics to randomly trigger a first incorrect event for '/', and a second event when the actual landing route is finally resolved (e.g. '/foo/'). This affects the bounce rate metric that we observe in Google Analytics.

As reported by @Dadibom in #204, this race condition can be reproduced by introducing a delay in the route resolution path (e.g. beforeRouteEnter()).

**What is the new behavior (if this is a feature change)?**
The updated code for _pageviewOnLoad_ checks whether the Vue Router is ready before posting the first event. If it is not ready, it will eventually post the resolved route event as per the `afterEach()` subscription.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [X] Fix/Feature: Docs have been added/updated
- [X] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
We have successfully tested this fix under different loading scenarios; including delayed beforeRouteEnter() for a non-home page and delayed vue-analytics initialization.