### PR TITLE
feat: add tracker name

### DIFF
--- a/__tests__/create-trackers.spec.js
+++ b/__tests__/create-trackers.spec.js
@@ -18,6 +18,17 @@ it ('should initialize single tracker', () => {
   expect(window.ga).not.toBeCalledWith('set', 'sendHitTask', null)
 })
 
+it ('should initialize single tracker with tracker name', () => {
+  mockUpdate({
+    id: 'UA-1234-1',
+    trackerName: 'trackerName'
+  })
+
+  createTrackers()
+  expect(window.ga).toBeCalledWith('create', config.id, 'auto', {})
+  expect(window.ga).not.toBeCalledWith('set', 'sendHitTask', null)
+})
+
 it ('should initialize multiple trackers', () => {
   mockUpdate({ id: [ 'UA-1234-1', 'UA-1234-2' ] })
 
@@ -25,6 +36,19 @@ it ('should initialize multiple trackers', () => {
 
   mockGetId().forEach((id) => {
     expect(window.ga).toBeCalledWith('create', id, 'auto', { 'name': getTracker(id) })
+  })
+})
+
+it ('should initialize multiple trackers with tracker name', () => {
+  mockUpdate({
+    id: [ 'UA-1234-1', 'UA-1234-2' ],
+    trackerName: 'trackerName'
+  })
+
+  createTrackers()
+
+  mockGetId().forEach((id) => {
+    expect(window.ga).toBeCalledWith('create', id, 'auto', 'trackerName', { 'name': getTracker(id) })
   })
 })
 

--- a/__tests__/lib/event.spec.js
+++ b/__tests__/lib/event.spec.js
@@ -1,23 +1,39 @@
-import Vue from 'vue'
-import VueAnalytics from '../../src'
-
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+  const VueAnalytics = require('../../src/index').default
+
   window.ga.mockClear()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should track an event', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.event('foo', 'bar')
   expect(window.ga).toBeCalledWith('send', 'event', 'foo', 'bar')
+})
+
+it ('should track an event with tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.event('foo', 'bar')
+  expect(window.ga).toBeCalledWith('trackerName.send', 'event', 'foo', 'bar')
 })

--- a/__tests__/lib/exception.spec.js
+++ b/__tests__/lib/exception.spec.js
@@ -1,28 +1,49 @@
-import Vue from 'vue'
 import VueAnalytics from '../../src'
 
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+
   window.ga.mockClear()
 
   Vue.config.errorHandler = jest.fn()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should track an error exception', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.exception('bad stuff', true)
 
   expect(window.ga).toBeCalledWith('send', 'exception', {
+    exDescription: 'bad stuff',
+    exFatal: true
+  })
+})
+
+it ('should track an error exception with tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.exception('bad stuff', true)
+
+  expect(window.ga).toBeCalledWith('trackerName.send', 'exception', {
     exDescription: 'bad stuff',
     exFatal: true
   })

--- a/__tests__/lib/require.spec.js
+++ b/__tests__/lib/require.spec.js
@@ -1,29 +1,50 @@
-import Vue from 'vue'
-import VueAnalytics from '../../src'
-
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+  const VueAnalytics = require('../../src/index').default
+
   window.ga.mockClear()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should require a plugin', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.require('myplugin')
 
   expect(window.ga).toBeCalledWith('require', 'myplugin')
 })
 
+it ('should require a plugin with a tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.require('myplugin')
+
+  expect(window.ga).toBeCalledWith('trackerName.require', 'myplugin')
+})
+
 it ('should require a plugin with options', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.require('myplugin', {
     foo: 'bar'
   })

--- a/__tests__/lib/set.spec.js
+++ b/__tests__/lib/set.spec.js
@@ -1,35 +1,73 @@
-import Vue from 'vue'
-import VueAnalytics from '../../src'
-
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+  const VueAnalytics = require('../../src/index').default
+
   window.ga.mockClear()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should set a variable on Google Analytics', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.set('foo', 'bar')
 
   expect(window.ga).toBeCalledWith('set', 'foo', 'bar')
 })
 
+it ('should set a variable on Google Analytics with tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.set('foo', 'bar')
+
+  expect(window.ga).toBeCalledWith('trackerName.set', 'foo', 'bar')
+})
+
 it ('should set a variable on Google Analytics with an object literal', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.set({
     fieldName: 'foo',
     fieldValue: 'bar'
   })
 
   expect(window.ga).toBeCalledWith('set', {
+    fieldName: 'foo',
+    fieldValue: 'bar'
+  })
+})
+
+it ('should set a variable on Google Analytics with an object literal with tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.set({
+    fieldName: 'foo',
+    fieldValue: 'bar'
+  })
+
+  expect(window.ga).toBeCalledWith('trackerName.set', {
     fieldName: 'foo',
     fieldValue: 'bar'
   })

--- a/__tests__/lib/social.spec.js
+++ b/__tests__/lib/social.spec.js
@@ -1,28 +1,48 @@
-import Vue from 'vue'
-import VueAnalytics from '../../src'
-
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+  const VueAnalytics = require('../../src/index').default
+
   window.ga.mockClear()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should track a social interaction', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.social('Facebook', 'like', 'http://foo.com')
   expect(window.ga).toBeCalledWith('send', 'social', 'Facebook', 'like', 'http://foo.com')
 })
 
+it ('should track a social interaction with a tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.social('Facebook', 'like', 'http://foo.com')
+  expect(window.ga).toBeCalledWith('trackerName.send', 'social', 'Facebook', 'like', 'http://foo.com')
+})
+
 it ('should track a social interaction with an object literal', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.social({
     socialNetwork: 'Facebook',
     socialAction: 'like',
@@ -30,6 +50,25 @@ it ('should track a social interaction with an object literal', () => {
   })
 
   expect(window.ga).toBeCalledWith('send', 'social', {
+    socialNetwork: 'Facebook',
+    socialAction: 'like',
+    socialTarget: 'http://foo.com'
+  })
+})
+
+it ('should track a social interaction with an object literal with a tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.social({
+    socialNetwork: 'Facebook',
+    socialAction: 'like',
+    socialTarget: 'http://foo.com'
+  })
+
+  expect(window.ga).toBeCalledWith('trackerName.send', 'social', {
     socialNetwork: 'Facebook',
     socialAction: 'like',
     socialTarget: 'http://foo.com'

--- a/__tests__/lib/time.spec.js
+++ b/__tests__/lib/time.spec.js
@@ -1,29 +1,50 @@
-import Vue from 'vue'
-import VueAnalytics from '../../src'
-
 window.ga = jest.fn()
 
 let $vm
 
-beforeEach(() => {
+const initContext = (options) => {
+  const Vue = require('vue')
+  const VueAnalytics = require('../../src/index').default
+
   window.ga.mockClear()
 
-  Vue.use(VueAnalytics, {
-    id: 'UA-1234-5'
-  })
+  Vue.use(VueAnalytics, options)
 
   $vm = new Vue({})
 
   $vm.$mount()
+}
+
+beforeEach(() => {
+  jest.resetModules()
 })
 
 it ('should track timing', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.time('category', 'variable', 123, 'label')
 
   expect(window.ga).toBeCalledWith('send', 'timing', 'category', 'variable', 123, 'label')
 })
 
+it ('should track timing with a tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.time('category', 'variable', 123, 'label')
+
+  expect(window.ga).toBeCalledWith('trackerName.send', 'timing', 'category', 'variable', 123, 'label')
+})
+
 it ('should track timing with an object literal', () => {
+  initContext({
+    id: 'UA-1234-5'
+  })
+
   $vm.$ga.time({
     timingCategory: 'category',
     timingVar: 'variable',
@@ -32,6 +53,27 @@ it ('should track timing with an object literal', () => {
   })
 
   expect(window.ga).toBeCalledWith('send', 'timing', {
+    timingCategory: 'category',
+    timingVar: 'variable',
+    timingValue: 123,
+    timingLabel: 'label'
+  })
+})
+
+it ('should track timing with an object literal with a tracker name', () => {
+  initContext({
+    id: 'UA-1234-5',
+    trackerName: 'trackerName'
+  })
+
+  $vm.$ga.time({
+    timingCategory: 'category',
+    timingVar: 'variable',
+    timingValue: 123,
+    timingLabel: 'label'
+  })
+
+  expect(window.ga).toBeCalledWith('trackerName.send', 'timing', {
     timingCategory: 'category',
     timingVar: 'variable',
     timingValue: 123,

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ import { merge, noop } from './helpers'
 const defaultConfig = {
   $vue: null,
   id: null,
+  trackerName: null,
   router: null,
   fields: {},
   customIdFields: {},
@@ -71,6 +72,10 @@ export function reset () {
 
 export function getId () {
   return !config.id ? [] : [].concat(config.id)
+}
+
+export function getTrackerName () {
+  return config.trackerName
 }
 
 export default config

--- a/src/create-trackers.js
+++ b/src/create-trackers.js
@@ -1,6 +1,6 @@
 import set from 'lib/set'
 import query from 'lib/query'
-import config, { getId } from './config'
+import config, { getId, getTrackerName } from './config'
 import { getTracker } from './helpers'
 
 export default function createTrackers () {
@@ -13,6 +13,7 @@ export default function createTrackers () {
   }
 
   const ids = getId()
+  const trackerName = getTrackerName()
 
   if (config.debug.enabled) {
     window.ga_debug = {
@@ -25,7 +26,11 @@ export default function createTrackers () {
     const customIdConfig = config.customIdFields[domain] || {}
     const options = ids.length > 1 ? { ...config.fields, ...customIdConfig, name } : config.fields
 
-    window.ga('create', (domain.id || domain), 'auto', options)
+    if (trackerName) {
+      window.ga('create', (domain.id || domain), 'auto', trackerName, options)
+    } else {
+      window.ga('create', (domain.id || domain), 'auto', options)
+    }
   })
 
   config.beforeFirstHit()

--- a/src/lib/event.js
+++ b/src/lib/event.js
@@ -1,5 +1,9 @@
 import query from 'lib/query'
+import { getTrackerName } from './../config'
 
 export default function event (...args) {
-  query('send', 'event', ...args)
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.send` : 'send'
+
+  query(command, 'event', ...args)
 }

--- a/src/lib/exception.js
+++ b/src/lib/exception.js
@@ -1,8 +1,11 @@
 import query from 'lib/query'
-import config from '../config'
+import config, { getTrackerName } from '../config'
 
 const exception = (error, fatal = false) => {
-  query('send', 'exception', {
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.send` : 'send'
+
+  query(command, 'exception', {
     exDescription: error,
     exFatal: fatal
   })

--- a/src/lib/page.js
+++ b/src/lib/page.js
@@ -1,4 +1,4 @@
-import config from '../config'
+import config, { getTrackerName } from '../config'
 import set from 'lib/set'
 import screenview from 'lib/screenview'
 import query from 'lib/query'
@@ -32,7 +32,10 @@ export default function page (...args) {
     // We can call with `page('/my/path')`
     let page = typeof args[0] === 'object' ? args[0].page : args[0]
     set('page', page)
-    query('send', 'pageview', ...args)
+
+    const trackerName = getTrackerName()
+    const command = trackerName ? `${trackerName}.send` : 'send'
+    query(command, 'pageview', ...args)
   }
 }
 

--- a/src/lib/require.js
+++ b/src/lib/require.js
@@ -1,10 +1,14 @@
 import query from 'lib/query'
+import { getTrackerName } from '../config'
 
 export default function (...args) {
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.require` : 'require'
+
   if (args.length == 2) {
-    query('require', args[0], args[1])
+    query(command, args[0], args[1])
     return
   }
 
-  query('require', args[0])
+  query(command, args[0])
 }

--- a/src/lib/set.js
+++ b/src/lib/set.js
@@ -1,10 +1,14 @@
 import query from 'lib/query'
+import { getTrackerName } from './../config'
 
 export default function set (...args) {
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.set` : 'set'
+
   if (typeof args[0] === 'object' && args[0].constructor === Object) {
-    query('set', args[0])
+    query(command, args[0])
     return
   }
 
-  query('set', args[0], args[1])
+  query(command, args[0], args[1])
 }

--- a/src/lib/social.js
+++ b/src/lib/social.js
@@ -1,5 +1,9 @@
 import query from 'lib/query'
+import { getTrackerName } from '../config'
 
 export default function social (...args) {
-  query('send', 'social', ...args)
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.send` : 'send'
+
+  query(command, 'social', ...args)
 }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -1,5 +1,9 @@
 import query from 'lib/query'
+import { getTrackerName } from './../config'
 
 export default function time (...args) {
-  query('send', 'timing', ...args)
+  const trackerName = getTrackerName()
+  const command = trackerName ? `${trackerName}.send` : 'send'
+
+  query(command, 'timing', ...args)
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This PR adds the ability to define a [`trackerName`](https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers#naming_trackers) when creating a vue-analytics instance.

**What is the current behavior? (You can also link to an open issue here)**
vue-analytics [does not provide](https://github.com/MatteoGabriele/vue-analytics/issues/167) the ability to define a tracker with a name.

**What is the new behavior (if this is a feature change)?**
Now it is possible to add a tracker name when creating a vue-analytics instance:
```js
import Vue from 'vue'
import VueAnalytics from 'vue-analytics'

Vue.use(VueAnalytics, {
  id: 'UA-XXX-X',
  trackerName: '<TRACKER_NAME>'
})
```

**Does this PR introduce a breaking change?**
No, it should not.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [X] Fix/Feature: Docs have been added/updated
- [X] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
