### PR TITLE
fix: set event options as optional

### DIFF
--- a/vue-analytics.d.ts
+++ b/vue-analytics.d.ts
@@ -7,9 +7,9 @@ declare module 'vue-analytics' {
     (category: string, action?: string, label?: string, value?: number): void;
     (options: {
       eventCategory: string,
-      eventAction: string,
-      eventLabel: string,
-      eventValue: number
+      eventAction?: string,
+      eventLabel?: string,
+      eventValue?: number
     }): void;
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
As mentioned https://github.com/MatteoGabriele/vue-analytics/pull/258#discussion_r356786027 by @johnjcamilleri the options in the types should be optional.

**What is the current behavior? (You can also link to an open issue here)**
Options for the `eventFn` was not optional

**What is the new behavior (if this is a feature change)?**
Options for the `eventFn` is optional

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [x] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

