### PR TITLE
Improve typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "terser-webpack-plugin": "^2.2.1",
     "vue": "^2.6.10",
     "vue-router": "^3.1.3",
+    "vuex": "^3.1.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   }

--- a/vue-analytics.d.ts
+++ b/vue-analytics.d.ts
@@ -51,6 +51,138 @@ declare module 'vue-analytics' {
     }): void;
   }
   
+  interface EcommerceItem {
+    id: string;
+    name: string;
+    sku?: string;
+    category?: string;
+    price?: string;
+    quantity?: number;
+  }
+
+  interface EcommerceTransaction {
+    id: string;
+    affiliation?: string;
+    revenue?: string;
+    shipping?: string;
+    tax?: string;
+  }
+
+  interface EcommerceImpressionBase {
+    list?: string;
+    brand?: string;
+    category?: string;
+    variant?: string;
+    position?: number;
+    price?: string;
+  }
+
+  interface EcommerceImpressionWithId extends EcommerceImpressionBase {
+    id: string;
+  }
+
+  interface EcommerceImpressionWithName extends EcommerceImpressionBase {
+    name: string;
+  }
+
+  type EcommerceImpression = EcommerceImpressionWithId | EcommerceImpressionWithName;
+
+  interface EcommerceProductBase {
+    brand?: string;
+    category?: string;
+    variant?: string;
+    price?: string;
+    quantity?: number;
+    coupon?: string;
+    position?: number;
+  }
+
+  interface EcommerceProductWithId extends EcommerceProductBase {
+    id: string;
+  }
+
+  interface EcommerceProductWithName extends EcommerceProductBase {
+    name: string;
+  }
+
+  type EcommerceProduct = EcommerceImpressionWithId | EcommerceImpressionWithName;
+
+  type EcommerceAction = 
+    | 'click' 
+    | 'detail' 
+    | 'add' 
+    | 'remove' 
+    | 'checkout'
+    | 'checkout_option'
+    | 'purchase'
+    | 'refund'
+    | 'promo_click'
+
+  interface EcommerceActionData {
+    id?: string;
+    affiliation?: string;
+    revenue?: number;
+    tax?: number;
+    shipping?: number;
+    coupon?: string;
+    list?: string;
+    step?: number;
+    option?: string;
+  }
+
+  interface EcommercePromoBase {
+    creative?: string;
+    position?: string;
+  }
+
+  interface EcommercePromoWithId extends EcommercePromoBase {
+    id: string;
+  }
+
+  interface EcommercePromoWithName extends EcommercePromoBase {
+    name: string;
+  }
+
+  type EcommercePromo = EcommercePromoWithId | EcommercePromoWithName;
+
+  interface Ecommerce {
+    addItem(item: EcommerceItem): void;
+    addTransaction(transaction: EcommerceTransaction): void;
+    addProduct(product: EcommerceProduct): void;
+    addImpression(impression: EcommerceImpression): void;
+    setAction(action: EcommerceAction, data: EcommerceActionData): void;
+    addPromo(product: EcommercePromo): void;
+    send(): void;
+  }
+
+  interface screenviewFn {
+    (screen: string) :void;
+    (option: {
+      screenName: string;
+      [otherProperties: string]: any;
+    }): void;
+  }
+
+  interface requireFn {
+    (pluginName: string, options?: any): void
+  }
+
+  interface exceptionFn {
+    (exception: Error | string): void;
+  }
+
+  interface queryFn {
+    (...args: any[]): any;
+  }
+
+  interface analyticsMiddlewareFn {
+    <T>(store: Store<T>): void;
+  }
+
+  interface onAnalyticsReadyFn {
+    (): Promise<void>;
+  }
+  
   export interface InstallOptions {
     id: string | string[] | (() => string) | (() => Promise<string>) | Promise<string>,
     router?: VueRouter,
@@ -107,7 +239,7 @@ declare module 'vue-analytics' {
     analyticsMiddleware: any;
     onAnalyticsReady: () => Promise<void>;
     event: eventFn;
-    ecommerce: any;
+    ecommerce: Ecommerce;
     set: setFn;
     page: pageFn;
     query: any;

--- a/vue-analytics.d.ts
+++ b/vue-analytics.d.ts
@@ -2,6 +2,7 @@
 declare module 'vue-analytics' {
   import _Vue, { PluginFunction } from 'vue';
   import VueRouter, { Route } from 'vue-router';
+  import { Store } from 'vuex';
 
   interface eventFn {
     (category: string, action?: string, label?: string, value?: number): void;
@@ -50,7 +51,7 @@ declare module 'vue-analytics' {
       timingLabel: string
     }): void;
   }
-  
+
   interface EcommerceItem {
     id: string;
     name: string;
@@ -236,21 +237,34 @@ declare module 'vue-analytics' {
 
   export default class VueAnalytics {
     static install(Vue: typeof _Vue, options: InstallOptions): void;
-    analyticsMiddleware: any;
-    onAnalyticsReady: () => Promise<void>;
+    analyticsMiddleware<T>(store: Store<T>): void;
+    onAnalyticsReady: onAnalyticsReadyFn;
     event: eventFn;
     ecommerce: Ecommerce;
     set: setFn;
     page: pageFn;
-    query: any;
-    screenview: ((screen: string) => void) | ((option: { screenName: string, [otherProperties: string]: any }) => void);
+    query: queryFn;
+    screenview: screenviewFn;
     time: timeFn;
-    require: (pluginName: string, options?: any) => void;
-    exception: (exception: Error | string) => void;
+    require: requireFn;
+    exception: exceptionFn;
     social: socialFn;
     disable: () => void;
     enable: () => void;
   }
+
+  export const analyticsMiddleware: analyticsMiddlewareFn;
+  export const onAnalyticsReady: onAnalyticsReadyFn;
+  export const event: eventFn;
+  export const ecommerce: Ecommerce;
+  export const set: setFn;
+  export const page: pageFn;
+  export const query: queryFn;
+  export const screenview: screenviewFn;
+  export const time: timeFn;
+  export const require: requireFn;
+  export const exception: exceptionFn;
+  export const social: socialFn;
 
   module 'vue/types/options' {
     interface ComponentOptions<V extends _Vue> {

--- a/vue-analytics.d.ts
+++ b/vue-analytics.d.ts
@@ -50,58 +50,60 @@ declare module 'vue-analytics' {
       timingLabel: string
     }): void;
   }
+  
+  export interface InstallOptions {
+    id: string | string[] | (() => string) | (() => Promise<string>) | Promise<string>,
+    router?: VueRouter,
+    ignoreRoutes?: string[],
+    debug?: {
+      enabled?: boolean,
+      trace?: boolean,
+      sendHitTask?: boolean
+    },
+    batch?: {
+      enabled?: boolean,
+      amount?: number,
+      delay?: number
+    },
+    linkers?: string[],
+    customResourceURL?: string,
+    ecommerce?: {
+      enabled?: boolean,
+      enhanced?: boolean,
+      options?: any
+    },
+    autoTracking?: {
+      exception?: boolean,
+      exceptionLogs?: boolean,
+      screenview?: boolean,
+      pageviewOnLoad?: boolean,
+      page?: boolean,
+      pageviewTemplate?: (route: Route) => pageDetails,
+      transformQueryString?: boolean,
+      prependBase?: boolean,
+      skipSamePath: boolean,
+      shouldRouterUpdate: (to: Route, from: Route) => string,
+      untracked?: boolean
+    },
+    fields?: {
+      [field: string]: any
+    },
+    customIdFields?: {
+      [id: string]: {
+        [field: string]: any
+      }
+    },
+    disabled?: boolean | (() => boolean) | (() => Promise<boolean>) | Promise<boolean>,
+    checkDuplicatedScript?: boolean,
+    disableScriptLoader?: boolean
+    set?: { field: string, value: string }[],
+    commands?: any,
+    beforeFirstHit?: () => void,
+    ready?: () => void
+  }
 
   export default class VueAnalytics {
-    static install(Vue: typeof _Vue, options: {
-      id: string | string[] | (() => string) | (() => Promise<string>) | Promise<string>,
-      router?: VueRouter,
-      ignoreRoutes?: string[],
-      debug?: {
-        enabled?: boolean,
-        trace?: boolean,
-        sendHitTask?: boolean
-      },
-      batch?: {
-        enabled?: boolean,
-        amount?: number,
-        delay?: number
-      },
-      linkers?: string[],
-      customResourceURL?: string,
-      ecommerce?: {
-        enabled?: boolean,
-        enhanced?: boolean,
-        options?: any
-      },
-      autoTracking?: {
-        exception?: boolean,
-        exceptionLogs?: boolean,
-        screenview?: boolean,
-        pageviewOnLoad?: boolean,
-        page?: boolean,
-        pageviewTemplate?: (route: Route) => pageDetails,
-        transformQueryString?: boolean,
-        prependBase?: boolean,
-        skipSamePath: boolean,
-        shouldRouterUpdate: (to: Route, from: Route) => string,
-        untracked?: boolean
-      },
-      fields?: {
-        [field: string]: any
-      },
-      customIdFields?: {
-        [id: string]: {
-          [field: string]: any
-        }
-      },
-      disabled?: boolean | (() => boolean) | (() => Promise<boolean>) | Promise<boolean>,
-      checkDuplicatedScript?: boolean,
-      disableScriptLoader?: boolean
-      set?: { field: string, value: string }[],
-      commands?: any,
-      beforeFirstHit?: () => void,
-      ready?: () => void
-    }): void;
+    static install(Vue: typeof _Vue, options: InstallOptions): void;
     analyticsMiddleware: any;
     onAnalyticsReady: () => Promise<void>;
     event: eventFn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8542,6 +8542,11 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuex@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.2.tgz#a2863f4005aa73f2587e55c3fadf3f01f69c7d4d"
+  integrity sha512-ha3jNLJqNhhrAemDXcmMJMKf1Zu4sybMPr9KxJIuOpVcsDQlTBYLLladav2U+g1AvdYDG5Gs0xBTb0M5pXXYFQ==
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Improves typings 

**What is the current behavior? (You can also link to an open issue here)**
1. typings for `options` for `install` method are inlined, making them very hard to use in app https://github.com/MatteoGabriele/vue-analytics/pull/258#issuecomment-565244346
2. library function exports e.g. `event`, `exception`, `time`, etc. are missing, so it's impossible to import them
3. ecommerce types are missing

**What is the new behavior (if this is a feature change)?**
1. extracted `option` typings for `install` method
2. added library functions into exports
3. added typings for ecommerce.

**Does this PR introduce a breaking change?**
It might break compilation for those who already use typescript together with vue-analytics.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [x] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
Let me know if those typings for `ecommerce` are too much.

I also added `vuex` into `devDependencies` to pull `Store<T>` type from there and have better declarations for `analyticsMiddleware`.