### PR TITLE
Update typings for `set` function value argument

### DIFF
--- a/vue-analytics.d.ts
+++ b/vue-analytics.d.ts
@@ -26,11 +26,14 @@ declare module 'vue-analytics' {
     (route: VueRouter): void;
   }
 
+  interface SetFieldValue {
+    field: string;
+    value: any;
+  }
+
   interface setFn {
-    (fieldName: string, fieldValue: string): void;
-    (options: {
-      field: string, value: string
-    }): void;
+    (fieldName: string, fieldValue: any): void;
+    (options: Record<string, any>): void;
   }
 
   interface socialFn {
@@ -229,7 +232,7 @@ declare module 'vue-analytics' {
     disabled?: boolean | (() => boolean) | (() => Promise<boolean>) | Promise<boolean>,
     checkDuplicatedScript?: boolean,
     disableScriptLoader?: boolean
-    set?: { field: string, value: string }[],
+    set?: SetFieldValue[],
     commands?: any,
     beforeFirstHit?: () => void,
     ready?: () => void


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes typings for `set`-related functionality.

**What is the current behavior? (You can also link to an open issue here)**
Value in `set` is limited to `string` only which doesn't allow to use the following config:
```
const options: InstallOptions = {
  id: "XXX",
  set: [{ field: "anonymizeIp", value: true }],
};
```
And the following typing for `set` function itself is incorrect, which also doesn't allow the following calls:

```
set('anonymizeIp', true)
set({ anonymizeIp: true })
```

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic-release [guidelines](https://github.com/semantic-release/semantic-release#commit-message-format)
- [x] Fix/Feature: Docs have been added/updated
- [x] Fix/Feature: Tests have been added; existing tests pass

**Other information**:
I used type `any` instead of `string | number | boolean` to avoid narrowing it too much.
