### PR TITLE
Call bootstrap on demand

### DIFF
--- a/docs/script-loader.md
+++ b/docs/script-loader.md
@@ -31,6 +31,29 @@ Vue.use(VueAnalytics, {
 })
 ```
 
+### Bootstrap later
+It is possible to setup the entire plugin options, but to bootstrap it later on whenever the user decide too. This could also be useful for any GDPR proof projects.
+
+```js
+import Vue from 'vue'
+import VueAnalytics from 'vue-analytics'
+
+Vue.use(VueAnalytics, {
+  id: 'UA-XXX-X',
+  bootstrap: false
+})
+```
+
+Later on you can simply import and call the boostrap function
+
+```js
+import { bootstrap, hasScript } from '@/vendor/vue-analytics.js'
+
+if (!hasScript()){
+  bootstrap()
+}
+```
+
 ### Important
 It is not possible for the plugin to remove the initial trackers, because it needs them to create all methods for the multi-tracking feature.
 **If you can't remove initial trackers, don't use this plugin: the outcome could be unpredictable.**

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,9 @@ const defaultConfig = {
   // https://github.com/MatteoGabriele/vue-analytics/issues/103
   disabled: false,
 
+  // https://github.com/MatteoGabriele/vue-analytics/issues/240
+  bootstrap: true,
+
   customResourceURL: null,
 
   set: [],

--- a/src/config.js
+++ b/src/config.js
@@ -62,7 +62,7 @@ const defaultConfig = {
 let config = { ...defaultConfig }
 
 export function update (params) {
-  merge(config, params)
+  return merge(config, params)
 }
 
 export function reset () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import bootstrap from './bootstrap'
+import _bootstrap from './bootstrap'
 import lib from './lib'
 import { update } from './config'
 import * as helpers from './helpers'
@@ -7,13 +7,18 @@ import { autotracking as expectionAutotracking } from './lib/exception'
 import vuexMiddleware from './vuex-middleware'
 
 export default function install (Vue, options = {}) {
-  update({ ...options, $vue: Vue })
+  options = update({ ...options, $vue: Vue })
 
   Vue.directive('ga', ga)
   Vue.prototype.$ga = Vue.$ga = lib
 
   expectionAutotracking(Vue)
-  bootstrap()
+
+  if (!options.bootstrap)   {
+    return
+  }
+
+  _bootstrap()
 }
 
 // Vuex middleware
@@ -21,6 +26,7 @@ export const analyticsMiddleware = vuexMiddleware
 
 // Helpers
 export const onAnalyticsReady = helpers.onAnalyticsReady
+export const hasScript = helpers.hasScript
 
 // Event library
 export const event = lib.event
@@ -33,5 +39,4 @@ export const time = lib.time
 export const require = lib.require
 export const exception = lib.exception
 export const social = lib.social
-
-
+export const bootstrap = _bootstrap

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -10,6 +10,7 @@ import ecommerce from './ecommerce'
 import screenview from './screenview'
 import config from '../config'
 import noga from '../no-ga'
+import bootstrap from '../bootstrap'
 
 export default {
   event,
@@ -22,6 +23,7 @@ export default {
   time,
   screenview,
   ecommerce,
+  bootstrap,
   disable: () => noga(true),
   enable: () => noga(false),
   commands: config.commands


### PR DESCRIPTION
This PR introduce the ability to call the boostrap function later, like in vue-gtag. 
